### PR TITLE
A single cassandra node in the autoscaling group makes no sense, as t…

### DIFF
--- a/src/main/template/cassandra.yaml
+++ b/src/main/template/cassandra.yaml
@@ -1035,7 +1035,7 @@ Resources:
       LaunchConfigurationName: !Ref launchConfiguration
       MaxSize: 30
       MinSize: 0
-      DesiredCapacity: 1
+      DesiredCapacity: 0
       VPCZoneIdentifier:
         - Fn::Select:
           - 0


### PR DESCRIPTION
…he Ec2Snitch distributes evenly among availability zones, resulting in two seed nodes still being under full load.